### PR TITLE
add env var to enable pprof for mcpo

### DIFF
--- a/cmd/mcp-operator/app/app.go
+++ b/cmd/mcp-operator/app/app.go
@@ -104,9 +104,6 @@ func (o *Options) runInit(ctx context.Context) error {
 	}
 
 	if o.CRDFlags.Install {
-		if err != nil {
-			return fmt.Errorf("error building setup client: %w", err)
-		}
 		setupLog.Info("CRD installation configured, deploying CRDs ...")
 		crds := crdinstall.CRDs()
 		for _, crd := range crds {
@@ -176,6 +173,7 @@ func (o *Options) run(ctx context.Context) error {
 			RecoverPanic: ptr.To(true),
 		},
 		HealthProbeBindAddress:  o.ProbeAddr,
+		PprofBindAddress:        o.PprofAddr,
 		LeaderElection:          o.EnableLeaderElection,
 		LeaderElectionID:        "mcpo.openmcp.cloud",
 		LeaderElectionNamespace: o.LeaseNamespace,


### PR DESCRIPTION
**What this PR does / why we need it**:
The environment variable `ENABLE_PROFILER` can be set to `true` to expose pprof metrics for the MCPO.
The environment variable `PROFILER_ADDRESS` can be used to specify the address, it defaults to `:8082` if not set.

To view the data:
- Use `kubectl port-forward pod/<pod-name> 8082` to reach the pprof endpoint from your local terminal.
- `curl -s "http://127.0.0.1:8082/debug/pprof/profile" > ./tmp/cpu-profile.out`
- `go tool pprof -http=:8080 ./tmp/cpu-profile.out`
