### PR TITLE
chore(deps): renovate "go mod tidy" after update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Renovate calls "go mod tidy" after go dependency update.
Builds are failing in Renovate's PR currently

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
