### PR TITLE
fix typo in helm chart

### DIFF
--- a/charts/mcp-operator/templates/configmap-mcp-operator-config.yaml
+++ b/charts/mcp-operator/templates/configmap-mcp-operator-config.yaml
@@ -13,8 +13,8 @@ data:
       immutability:
       {{- .Values.architecture.immutability | toYaml | nindent 8 }}
       {{- end }}
-      {{- if and .Values.apiServer .Values.apiServer.architecture }}
-      apiServer:
-        version: {{ .Values.apiServer.architecture.version | default "v1" }}
-        allowOverride: {{ .Values.apiServer.architecture.allowOverride | default false }}
+      {{- if and .Values.apiserver .Values.apiserver.architecture }}
+      apiserver:
+        version: {{ .Values.apiserver.architecture.version | default "v1" }}
+        allowOverride: {{ .Values.apiserver.architecture.allowOverride | default false }}
       {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a wrong template in the helm chart.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a typo in the helm chart which caused the APIServer architecture config to not be properly propagated.
```
