### PR TITLE
fix: authorization controller triggers deletion clusteradmin

### DIFF
--- a/internal/controller/core/authorization/testdata/test-09/apiserver.yaml
+++ b/internal/controller/core/authorization/testdata/test-09/apiserver.yaml
@@ -1,0 +1,42 @@
+apiVersion: core.openmcp.cloud/v1alpha1
+kind: APIServer
+metadata:
+  name: test
+  namespace: test
+  labels:
+    "openmcp.cloud/mcp-generation": "1"
+spec:
+  desiredRegion:
+    direction: central
+    name: europe
+  type: GardenerDedicated
+status:
+  conditions:
+    - lastTransitionTime: "2024-05-22T08:23:47Z"
+      status: "True"
+      type: apiServerHealthy
+  observedGenerations:
+    internalConfiguration: -1
+    managedControlPlane: 1
+    resource: 0
+  adminAccess:
+    creationTimestamp: "2024-05-22T08:23:47Z"
+    expirationTimestamp: "2024-11-18T08:23:47Z"
+    kubeconfig: |
+      apiVersion: v1
+      clusters:
+      - name: apiserver
+        cluster:
+          server: https://apiserver.dummy
+          certificate-authority-data: ZHVtbXkK
+      contexts:
+      - name: apiserver
+        context:
+          cluster: apiserver
+          user: apiserver
+      current-context: apiserver
+      users:
+      - name: apiserver
+        user:
+          client-certificate-data: ZHVtbXkK
+          client-key-data: ZHVtbXkK

--- a/internal/controller/core/authorization/testdata/test-09/authorization.yaml
+++ b/internal/controller/core/authorization/testdata/test-09/authorization.yaml
@@ -1,0 +1,18 @@
+apiVersion: core.openmcp.cloud/v1alpha1
+kind: Authorization
+metadata:
+  name: test
+  namespace: test
+  labels:
+    "openmcp.cloud/mcp-generation": "1"
+spec:
+  roleBindings:
+    - role: admin
+      subjects:
+        - kind: User
+          name: admin
+    - role: admin
+      subjects:
+        - kind: ServiceAccount
+          name: pipeline
+          namespace: automate

--- a/internal/controller/core/authorization/testdata/test-09/clusteradmin.yaml
+++ b/internal/controller/core/authorization/testdata/test-09/clusteradmin.yaml
@@ -1,0 +1,9 @@
+apiVersion: core.openmcp.cloud/v1alpha1
+kind: ClusterAdmin
+metadata:
+  name: test
+  namespace: test
+spec:
+  subjects:
+    - kind: User
+      name: admin


### PR DESCRIPTION
**What this PR does / why we need it**:

When the authorization component is being deleted it must be ensured that all `ClusterAdmin` resources with the same name as the authorization component are being deleted before the deletion can continue.
Otherwise the `ClusterAdmin` resource will be orphaned and can't be deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Ensure that the corresponding ClusterAdmin resource is deleted before the ManagedControlPlane is being deleted.
```
