### PR TITLE
fix: Change OIDC flag for generated MCP kubeconfigs

### DIFF
--- a/api/core/v1alpha1/authentication_types.go
+++ b/api/core/v1alpha1/authentication_types.go
@@ -9,10 +9,11 @@ const (
 	OIDCParameterClientID     = "oidc-client-id"
 	OIDCParameterClientSecret = "oidc-client-secret"
 	OIDCParameterExtraScope   = "oidc-extra-scope"
-	OIDCParameterUsePKCE      = "oidc-use-pkce"
+	OIDCParameterPKCEMethod   = "oidc-pkce-method"
 	OIDCParameterGrantType    = "grant-type"
 
 	OIDCDefaultExtraScopes = "offline_access,email,profile"
+	OIDCDefaultPKCEMethod  = "auto"
 	OIDCDefaultGrantType   = "auto"
 )
 

--- a/internal/controller/core/apiserver/utils/access.go
+++ b/internal/controller/core/apiserver/utils/access.go
@@ -283,7 +283,7 @@ func CreateOIDCKubeconfig(ctx context.Context, crateClient client.Client, cluste
 	contexts := make(map[string]*clientcmdapi.Context)
 
 	flags := map[string]openmcpv1alpha1.SingleOrMultiStringValue{
-		openmcpv1alpha1.OIDCParameterUsePKCE:    {},
+		openmcpv1alpha1.OIDCParameterPKCEMethod: {Value: openmcpv1alpha1.OIDCDefaultPKCEMethod},
 		openmcpv1alpha1.OIDCParameterGrantType:  {Value: openmcpv1alpha1.OIDCDefaultGrantType},
 		openmcpv1alpha1.OIDCParameterExtraScope: {Values: strings.Split(openmcpv1alpha1.OIDCDefaultExtraScopes, ",")},
 	}

--- a/internal/controller/core/authentication/controller_test.go
+++ b/internal/controller/core/authentication/controller_test.go
@@ -268,7 +268,7 @@ var _ = Describe("CO-1153 Authentication Controller", func() {
 		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-extra-scope=email"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-extra-scope=profile"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-extra-scope=offline_access"))
-		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-use-pkce"))
+		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-pkce-method=auto"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--grant-type=auto"))
 
 		openIdConnect := getOpenIDConnect()
@@ -550,7 +550,7 @@ var _ = Describe("CO-1153 Authentication Controller", func() {
 		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-client-secret=myclientsecret"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-extra-scope=scope1"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-extra-scope=scope2"))
-		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-use-pkce"))
+		Expect(systemIdP.Exec.Args).To(ContainElements("--oidc-pkce-method=auto"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--grant-type=auto"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--extra-param=foo"))
 		Expect(systemIdP.Exec.Args).To(ContainElements("--extra-repeatable=bar1"))


### PR DESCRIPTION
**What this PR does / why we need it**:
When a user tries to login to an MCP with the kubeconfig that they received from a Secret in the workspace namespace, the user will receive...

```
Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
```

... for every kubectl command. This happends when you upgrade the oidc-plugin.

**Which issue(s) this PR fixes**:
Fixes #14 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
