### PR TITLE
chore: creates gh action for preparing a release

### DIFF
--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -1,0 +1,63 @@
+name: Create Release Branch and PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (minor, patch, major)'
+        required: false
+        default: 'minor'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create_release_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get last commit author
+        id: last_author
+        run: |
+          AUTHOR=$(git log -1 --pretty=format:'%ae')
+          echo "author_email=$AUTHOR" >> $GITHUB_OUTPUT
+
+      - name: Create release branch
+        run: |
+          BRANCH="release-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$BRANCH"
+          echo "RELEASE_BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Run release task and commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          task release:${{ github.event.inputs.release_type }}
+          git push origin "$RELEASE_BRANCH"
+
+      - name: Find GitHub username by email
+        id: find_user
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const email = process.env['AUTHOR_EMAIL'] || '${{ steps.last_author.outputs.author_email }}';
+            const { data: users } = await github.rest.search.users({ q: `${email} in:email` });
+            if (users.items.length > 0) {
+              core.setOutput('username', users.items[0].login);
+            } else {
+              core.setOutput('username', '');
+            }
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.RELEASE_BRANCH }}
+          title: "Release: ${{ github.event.inputs.release_type }}"
+          body: "Automated release PR for ${{ github.event.inputs.release_type }}"
+          assignees: ${{ steps.find_user.outputs.username }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Calls task release:minor for preparing a release as github action

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
