### PR TITLE
fix: sanitize chart version label for Flux OCI compatibility

### DIFF
--- a/charts/mcp-operator/templates/_helpers.tpl
+++ b/charts/mcp-operator/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Common labels
 */}}
 {{- define "mcp-operator.labels" -}}
 helm.sh/chart-name: {{ .Chart.Name }}
-helm.sh/chart-version: {{ .Chart.Version | quote }}
+helm.sh/chart-version: {{ .Chart.Version | replace "+" "_" | quote }}
 {{ include "mcp-operator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sanitize the `helm.sh/chart-version` label in `_helpers.tpl` by replacing `+` with `_`.

When deploying the mcp-operator Helm chart via **Flux HelmRelease** with an `OCIRepository` source (using `chartRef`), Flux appends a truncated OCI digest as [semver build metadata](https://semver.org/#spec-item-10) to the chart version. For example:

```
0.52.0  →  0.52.0+0d502f14f06f
```

The `+` character is **not valid in Kubernetes label values** (only alphanumeric, `-`, `_`, `.` are allowed). Since the `helm.sh/chart-version` label uses `.Chart.Version` directly, every resource with this label is rejected by the API server:

```
metadata.labels: Invalid value: "0.52.0+0d502f14f06f": a valid label must be an empty string
or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an
alphanumeric character
```

This affects all resources created by the chart.

The fix follows the [Helm best practices for labels](https://helm.sh/docs/chart_best_practices/labels/) which explicitly recommend `replace "+" "_"` for chart version in labels:

```diff
- helm.sh/chart-version: {{ .Chart.Version | quote }}
+ helm.sh/chart-version: {{ .Chart.Version | replace "+" "_" | quote }}
```

This is a no-op for standard Helm installs (where `.Chart.Version` never contains `+`) and only activates when Flux adds build metadata.

**Release note**:

```release-note
Fix Helm chart label validation error when deployed via Flux with OCIRepository chartRef by sanitizing `+` in chart version labels.
```